### PR TITLE
error serializing, remote errors

### DIFF
--- a/ext.js
+++ b/ext.js
@@ -1,0 +1,37 @@
+'use strict'
+
+class RemoteError extends Error {
+  constructor ({ message, stack, name, type, ...rest }) {
+    super(message)
+    var localStack = this.stack
+    this.stack = 'REMOTE STACK:\n' + stack + '\nLOCAL STACK:\n' + localStack
+    this.remoteName = name
+    Object.assign(this, rest)
+  }
+}
+
+function serializeError (k, v) {
+  if (v instanceof Error) {
+    return {
+      ...v,
+      type: 'MininetSerializedError',
+      name: v.name,
+      message: v.message,
+      stack: v.stack
+    }
+  }
+  return v
+}
+
+function parseExtendedTypes (k, v) {
+  if (v == null || typeof v !== 'object') return v
+  if (v.type === 'MininetSerializedError') {
+    return new RemoteError(v)
+  }
+  if (v.type === 'Buffer' && Array.isArray(v.data)) {
+    return Buffer.from(v.data)
+  }
+  return v
+}
+
+module.exports = { serializeError, parseExtendedTypes }

--- a/host.js
+++ b/host.js
@@ -1,26 +1,20 @@
 var net = require('net')
 var split = require('split2')
 var events = require('events')
+var ext = require('./ext')
+var parseExtendedTypes = ext.parseExtendedTypes
+var serializeError = ext.serializeError
 
 var sock = net.connect(process.env.MN_SOCK)
-
-function parseJsonBuffer (k, v) {
-  const isBuffer = v !== null &&
-    typeof v === 'object' &&
-    v.type === 'Buffer' &&
-    Array.isArray(v.data)
-  if (isBuffer) return Buffer.from(v.data)
-  return v
-}
 
 sock.write(process.env.MN_HEADER + '\n')
 sock.pipe(split()).on('data', function (data) {
   try {
-    data = JSON.parse(data, parseJsonBuffer)
+    data = JSON.parse(data, parseExtendedTypes)
   } catch (err) {
     return
   }
-  var opts = {from: data.from}
+  var opts = { from: data.from }
   exports.emit('message', data.name, data.data, opts)
   exports.emit('message:' + data.name, data.data, opts)
 })
@@ -37,13 +31,13 @@ exports.ref = function () {
 
 exports.send = function (name, data, opts) {
   if (!opts) opts = {}
-  sock.write(JSON.stringify({name: name, data: data, to: opts.to}) + '\n')
+  sock.write(JSON.stringify({ name: name, data: data, to: opts.to }, serializeError) + '\n')
 }
 
 exports.sendTo = function (host, name, data) {
-  exports.send(name, data, {to: host})
+  exports.send(name, data, { to: host })
 }
 
 exports.broadcast = function (name, data) {
-  exports.send(name, data, {to: '*'})
+  exports.send(name, data, { to: '*' })
 }

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ var path = require('path')
 var net = require('net')
 var events = require('events')
 var os = require('os')
+var ext = require('./ext')
+var parseExtendedTypes = ext.parseExtendedTypes
+var serializeError = ext.serializeError
 
 module.exports = Mininet
 
@@ -282,7 +285,7 @@ Host.prototype._onrpc = function (id, socket) {
 
   socket.pipe(split()).on('data', function (data) {
     try {
-      data = JSON.parse(data)
+      data = JSON.parse(data, parseExtendedTypes)
     } catch (err) {
       socket.destroy()
       return
@@ -419,10 +422,11 @@ Host.prototype.spawn = function (cmd, opts) {
 
   function send (name, data, from) {
     if (!proc.rpc) {
-      proc.pending.push({name: name, data: data, from: from})
+      proc.pending.push({ name: name, data: data, from: from })
       return
     }
-    proc.rpc.write(JSON.stringify({name: name, data: data, from: from}) + '\n')
+
+    proc.rpc.write(JSON.stringify({ name: name, data: data, from: from }, serializeError) + '\n')
   }
 
   function kill (sig) {


### PR DESCRIPTION
If an error occurs in a container, the error will become an empty object (in most cases), because `JSON.stringify({err: Error('msg')})` is `{"err":{}}`

This makes Error instances serialize and deserialize in a way that captures the original stack and message (and any other enumerable props that may be on the error). It also captures the constructor name of the error, and adds it to a `remoteName` property.